### PR TITLE
Update Field Formatting

### DIFF
--- a/mappers/stdlib/stdlib.go
+++ b/mappers/stdlib/stdlib.go
@@ -67,14 +67,14 @@ func (l *goLog) WithField(key string, value interface{}) loggers.Advanced {
 
 // WithFields returns an advanced logger with pre-set fields.
 func (l *goLog) WithFields(fields ...interface{}) loggers.Advanced {
-	s := make([]string, len(fields)/2)
+	s := make([]string, 0, len(fields)/2)
 	for i := 0; i+1 < len(fields); i = i + 2 {
 		key := fields[i]
 		value := fields[i+1]
 		s = append(s, fmt.Sprint(key, "=", value))
 	}
 
-	r := gologPostfixLogger{l, strings.Join(s, " ")}
+	r := gologPostfixLogger{l, "["+strings.Join(s, ", ")+"]"}
 	return mappers.NewAdvancedMap(&r)
 }
 
@@ -84,7 +84,9 @@ type gologPostfixLogger struct {
 }
 
 func (r *gologPostfixLogger) LevelPrint(lev mappers.Level, i ...interface{}) {
-	i = append(i, r.postfix)
+	if len(r.postfix) > 0 {
+		i = append(i, " ", r.postfix)
+	}
 	r.goLog.LevelPrint(lev, i...)
 }
 

--- a/mappers/stdlib/stdlib_test.go
+++ b/mappers/stdlib/stdlib_test.go
@@ -58,7 +58,7 @@ func TestLogWithFieldsOutput(t *testing.T) {
 	l, b := NewBufferedLog()
 	l.WithFields("test", true).Warn("This is a message.")
 
-	expected := "WARN  This is a message. test=true\n"
+	expected := "WARN  This is a message. [test=true]\n"
 	s := b.String()
 	start := strings.Index(s, "WARN")
 	actual := s[start:]
@@ -71,9 +71,22 @@ func TestLogWithFieldsfOutput(t *testing.T) {
 	l, b := NewBufferedLog()
 	l.WithFields("test", true, "Error", "serious").Errorf("This is a %s.", "message")
 
-	expected := "ERROR This is a message.   test=true Error=serious\n"
+	expected := "ERROR This is a message. [test=true, Error=serious]\n"
 	s := b.String()
 	start := strings.Index(s, "ERROR")
+	actual := s[start:]
+	if actual != expected {
+		t.Errorf("Log output mismatch %s (actual) != %s (expected)", actual, expected)
+	}
+}
+
+func TestLogWithFieldsLnOutput(t *testing.T) {
+	l, b := NewBufferedLog()
+	l.WithFields("test", true, "Error", "not so serious").Warnln("This is your last.")
+
+	expected := "WARN   This is your last. [test=true, Error=not so serious]\n"
+	s := b.String()
+	start := strings.Index(s, "WARN")
 	actual := s[start:]
 	if actual != expected {
 		t.Errorf("Log output mismatch %s (actual) != %s (expected)", actual, expected)

--- a/mappers/stdlib/testing.go
+++ b/mappers/stdlib/testing.go
@@ -56,14 +56,14 @@ func (l *goTestLog) WithField(key string, value interface{}) loggers.Advanced {
 
 // WithFields returns an advanced logger with pre-set fields.
 func (l *goTestLog) WithFields(fields ...interface{}) loggers.Advanced {
-	s := make([]string, len(fields)/2)
+	s := make([]string, 0, len(fields)/2)
 	for i := 0; i+1 < len(fields); i = i + 2 {
 		key := fields[i]
 		value := fields[i+1]
 		s = append(s, fmt.Sprint(key, "=", value))
 	}
 
-	r := goTestLogPostfixLogger{l, strings.Join(s, " ")}
+	r := goTestLogPostfixLogger{l, "["+strings.Join(s, ", ")+"]"}
 	return mappers.NewAdvancedMap(&r)
 }
 
@@ -73,7 +73,9 @@ type goTestLogPostfixLogger struct {
 }
 
 func (r *goTestLogPostfixLogger) LevelPrint(lev mappers.Level, i ...interface{}) {
-	i = append(i, r.postfix)
+	if len(r.postfix) > 0 {
+		i = append(i, " ", r.postfix)
+	}
 	r.goTestLog.LevelPrint(lev, i...)
 }
 


### PR DESCRIPTION
This fixes the issue where a number of spaces were inserted before fields. This was actually the number of parameters/2.

This ensures there is always 1 space, and adds "[" "]" around fields to separate them from the main content.

This means `WithFields("test", true, "Error", "not so serious").Warnln("This is your last.")` will log as `WARN   This is your last. [test=true, Error=not so serious]`.