### PR TITLE
Don't announce we're using the default logger.

### DIFF
--- a/mappers/stdlib/stdlib.go
+++ b/mappers/stdlib/stdlib.go
@@ -22,7 +22,6 @@ func NewDefaultLogger() loggers.Contextual {
 	g.logger = log.New(os.Stderr, "", log.Ldate|log.Ltime)
 
 	a := mappers.NewContextualMap(&g)
-	a.Debug("Now using Go's stdlib log package (via loggers/mappers/stdlib).")
 
 	return a
 }
@@ -33,7 +32,6 @@ func NewLogger(l *log.Logger) loggers.Contextual {
 	g.logger = l
 
 	a := mappers.NewContextualMap(&g)
-	a.Debug("Now using Go's stdlib log package (via loggers/mappers/stdlib).")
 
 	return a
 }


### PR DESCRIPTION
I like this library as an interface however I don't believe it needs to announce itself because this ends up being the first line of output from any program and potentially confusing for a user if they are trying to change logging. Either that or just leave it up to the user to configure the global/root logger of the package (and have it stay nil) and if they use it before configured it will panic. 

