### PR TITLE
Allow testing helper calls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,24 @@
 language: go
-go: 1.4
+
+sudo: false
+
+os:
+  - linux
+  - osx
+
+go:
+  - 1.9.x
+  - 1.10.x
+  - master
+
+install:
+  - mkdir -p $GOPATH/src/gopkg.in/birkirb/loggers.v1
+  - cp -r $GOPATH/src/github.com/birkirb/loggers/* $GOPATH/src/gopkg.in/birkirb/loggers.v1/
+
+script:
+  - go test -v ./...
+
+matrix:
+  allow_failures:
+    - go: 'master'
+  fast_finish: true

--- a/mappers/advanced.go
+++ b/mappers/advanced.go
@@ -3,6 +3,7 @@ package mappers
 // AdvancedMap maps a standard logger to an advanced logger interface.
 type AdvancedMap struct {
 	standardMap
+	t TestHelper
 }
 
 // NewAdvancedMap returns an advanced logger that is mapped via mapper.
@@ -16,62 +17,115 @@ func NewAdvancedMap(m LevelMapper) *AdvancedMap {
 	return &a
 }
 
+// TestHelper describes a *testing.T helper.
+type TestHelper interface {
+	Helper()
+}
+
+// NewAdvancedMapTesting returns an advanced logger that is mapped via mapper.
+// A TestHelper can be passed. This will be called if not nil.
+func NewAdvancedMapTesting(m LevelMapper, t TestHelper) *AdvancedMap {
+	var a AdvancedMap
+
+	if m != nil {
+		a.LevelMapper = m
+	}
+	a.t = t
+	return &a
+}
+
 // Debug should be used when logging exessive debug info.
 func (a *AdvancedMap) Debug(v ...interface{}) {
+	if a.t != nil {
+		a.t.Helper()
+	}
 	a.LevelPrint(LevelDebug, v...)
 }
 
 // Debugf works the same as Debug but supports formatting.
 func (a *AdvancedMap) Debugf(format string, v ...interface{}) {
+	if a.t != nil {
+		a.t.Helper()
+	}
 	a.LevelPrintf(LevelDebug, format, v...)
 }
 
 // Debugln works the same as Debug but supports formatting.
 func (a *AdvancedMap) Debugln(v ...interface{}) {
+	if a.t != nil {
+		a.t.Helper()
+	}
 	a.LevelPrintln(LevelDebug, v...)
 }
 
 // Info is a general function to log something.
 func (a *AdvancedMap) Info(v ...interface{}) {
+	if a.t != nil {
+		a.t.Helper()
+	}
 	a.LevelPrint(LevelInfo, v...)
 }
 
 // Infof works the same as Info but supports formatting.
 func (a *AdvancedMap) Infof(format string, v ...interface{}) {
+	if a.t != nil {
+		a.t.Helper()
+	}
 	a.LevelPrintf(LevelInfo, format, v...)
 }
 
 // Infoln works the same as Info but supports formatting.
 func (a *AdvancedMap) Infoln(v ...interface{}) {
+	if a.t != nil {
+		a.t.Helper()
+	}
 	a.LevelPrintln(LevelInfo, v...)
 }
 
 // Warn is useful for alerting about something wrong.
 func (a *AdvancedMap) Warn(v ...interface{}) {
+	if a.t != nil {
+		a.t.Helper()
+	}
 	a.LevelPrint(LevelWarn, v...)
 }
 
 // Warnf works the same as Warn but supports formatting.
 func (a *AdvancedMap) Warnf(format string, v ...interface{}) {
+	if a.t != nil {
+		a.t.Helper()
+	}
 	a.LevelPrintf(LevelWarn, format, v...)
 }
 
 // Warnln works the same as Warn but supports formatting.
 func (a *AdvancedMap) Warnln(v ...interface{}) {
+	if a.t != nil {
+		a.t.Helper()
+	}
 	a.LevelPrintln(LevelWarn, v...)
 }
 
 // Error should be used only if real error occures.
 func (a *AdvancedMap) Error(v ...interface{}) {
+	if a.t != nil {
+		a.t.Helper()
+	}
 	a.LevelPrint(LevelError, v...)
 }
 
 // Errorf works the same as Error but supports formatting.
 func (a *AdvancedMap) Errorf(format string, v ...interface{}) {
+	if a.t != nil {
+		a.t.Helper()
+	}
 	a.LevelPrintf(LevelError, format, v...)
 }
 
 // Errorln works the same as Error but supports formatting.
 func (a *AdvancedMap) Errorln(v ...interface{}) {
+	if a.t != nil {
+		a.t.Helper()
+	}
 	a.LevelPrintln(LevelError, v...)
 }

--- a/mappers/contextual.go
+++ b/mappers/contextual.go
@@ -22,6 +22,23 @@ func NewContextualMap(m ContextualMapper) *ContextualMap {
 	return &a
 }
 
+// NewContextualMapTesting returns an contextual logger that is mapped via mapper.
+// A TestHelper can be passed. This will be called if not nil.
+func NewContextualMapTesting(m ContextualMapper, t TestHelper) *ContextualMap {
+	var a ContextualMap
+	a.t = t
+
+	if m != nil {
+		if am := NewAdvancedMapTesting(m, t); am != nil {
+			a.AdvancedMap = *am
+		}
+		a.ContextualMapper = m
+	}
+
+	return &a
+}
+
+
 // WithField directly maps the loggers method.
 func (c *ContextualMap) WithField(key string, value interface{}) loggers.Advanced {
 	return c.ContextualMapper.WithField(key, value)

--- a/mappers/stdlib/testing.go
+++ b/mappers/stdlib/testing.go
@@ -18,17 +18,19 @@ type goTestLog struct {
 // NewDefaultLogger returns a Contextual logger using a *testing.T with Log/Logf output.
 // This allows logging to be redirected to the test where it belongs.
 func NewTestingLogger(t *testing.T) loggers.Contextual {
+	t.Helper()
 	var g goTestLog
 	g.logger = t
 
-	a := mappers.NewContextualMap(&g)
-	a.Debug("Now using Go's stdlib testing log (via loggers/mappers/stdlib).")
+	a := mappers.NewContextualMapTesting(&g, t)
+	a.Debugf("Now using Go's stdlib testing log (via loggers/mappers/stdlib).")
 
 	return a
 }
 
 // LevelPrint is a Mapper method
 func (l *goTestLog) LevelPrint(lev mappers.Level, i ...interface{}) {
+	l.logger.Helper()
 	v := []interface{}{lev}
 	v = append(v, i...)
 	l.logger.Log(v...)
@@ -36,6 +38,7 @@ func (l *goTestLog) LevelPrint(lev mappers.Level, i ...interface{}) {
 
 // LevelPrintf is a Mapper method
 func (l *goTestLog) LevelPrintf(lev mappers.Level, format string, i ...interface{}) {
+	l.logger.Helper()
 	f := "%s" + format
 	v := []interface{}{lev}
 	v = append(v, i...)
@@ -44,6 +47,7 @@ func (l *goTestLog) LevelPrintf(lev mappers.Level, format string, i ...interface
 
 // LevelPrintln is a Mapper method
 func (l *goTestLog) LevelPrintln(lev mappers.Level, i ...interface{}) {
+	l.logger.Helper()
 	v := []interface{}{lev}
 	v = append(v, i...)
 	l.logger.Log(v...)
@@ -64,7 +68,7 @@ func (l *goTestLog) WithFields(fields ...interface{}) loggers.Advanced {
 	}
 
 	r := goTestLogPostfixLogger{l, "["+strings.Join(s, ", ")+"]"}
-	return mappers.NewAdvancedMap(&r)
+	return mappers.NewAdvancedMapTesting(&r, l.logger)
 }
 
 type goTestLogPostfixLogger struct {
@@ -73,6 +77,7 @@ type goTestLogPostfixLogger struct {
 }
 
 func (r *goTestLogPostfixLogger) LevelPrint(lev mappers.Level, i ...interface{}) {
+	r.logger.Helper()
 	if len(r.postfix) > 0 {
 		i = append(i, " ", r.postfix)
 	}
@@ -80,6 +85,7 @@ func (r *goTestLogPostfixLogger) LevelPrint(lev mappers.Level, i ...interface{})
 }
 
 func (r *goTestLogPostfixLogger) LevelPrintf(lev mappers.Level, format string, i ...interface{}) {
+	r.logger.Helper()
 	if len(r.postfix) > 0 {
 		format = format + " %s"
 		i = append(i, r.postfix)
@@ -88,6 +94,7 @@ func (r *goTestLogPostfixLogger) LevelPrintf(lev mappers.Level, format string, i
 }
 
 func (r *goTestLogPostfixLogger) LevelPrintln(lev mappers.Level, i ...interface{}) {
+	r.logger.Helper()
 	i = append(i, r.postfix)
 	r.goTestLog.LevelPrintln(lev, i...)
 }


### PR DESCRIPTION
This will allow tests to pass through calling function names.

 Plus update CI to more modern Go versions and fix chicken+egg by importing ourselves at another path..